### PR TITLE
Skip disabled shared folders

### DIFF
--- a/lib/vagrant-joyent/action/sync_folders.rb
+++ b/lib/vagrant-joyent/action/sync_folders.rb
@@ -19,6 +19,9 @@ module VagrantPlugins
           ssh_info = env[:machine].ssh_info
 
           env[:machine].config.vm.synced_folders.each do |id, data|
+            # Ignore disabled shared folders
+            next if data[:disabled]
+
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]
 


### PR DESCRIPTION
Similar to the [virtualbox provider](https://github.com/mitchellh/vagrant/blob/master/plugins/providers/virtualbox/action/share_folders.rb#L40-L41), this pull request skips any disabled `synced_folder` definitions instead of using `rsync` on them.

It allows you to disable the `/vagrant` directory being rsynced to the joyent server.

``` ruby
Vagrant.configure('2') do |config|
  config.vm.box = 'dummy'

  config.vm.provider :joyent do |joyent|
    # ...
  end

  # Don't rsync the project to the server
  config.vm.synced_folder '.', '/vagrant', disabled: true
end
```
