### PR TITLE
Refactor gemspec

### DIFF
--- a/vagrant-joyent.gemspec
+++ b/vagrant-joyent.gemspec
@@ -21,38 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-expectations", "~> 2.12"
   s.add_development_dependency "rspec-mocks", "~> 2.12"
 
-  # The following block of code determines the files that should be included
-  # in the gem. It does this by reading all the files in the directory where
-  # this gemspec is, and parsing out the ignored files from the gitignore.
-  # Note that the entire gitignore(5) syntax is not supported, specifically
-  # the "!" syntax, but it should mostly work correctly.
-  root_path      = File.dirname(__FILE__)
-  all_files      = Dir.chdir(root_path) { Dir.glob("**/{*,.*}") }
-  all_files.reject! { |file| [".", ".."].include?(File.basename(file)) }
-  gitignore_path = File.join(root_path, ".gitignore")
-  gitignore      = File.readlines(gitignore_path)
-  gitignore.map!    { |line| line.chomp.strip }
-  gitignore.reject! { |line| line.empty? || line =~ /^(#|!)/ }
-
-  unignored_files = all_files.reject do |file|
-    # Ignore any directories, the gemspec only cares about files
-    next true if File.directory?(file)
-
-    # Ignore any paths that match anything in the gitignore. We do
-    # two tests here:
-    #
-    #   - First, test to see if the entire path matches the gitignore.
-    #   - Second, match if the basename does, this makes it so that things
-    #     like '.DS_Store' will match sub-directories too (same behavior
-    #     as git).
-    #
-    gitignore.any? do |ignore|
-      File.fnmatch(ignore, file, File::FNM_PATHNAME) ||
-        File.fnmatch(ignore, File.basename(file), File::FNM_PATHNAME)
-    end
-  end
-
-  s.files         = unignored_files
-  s.executables   = unignored_files.map { |f| f[/^bin\/(.*)/, 1] }.compact
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- spec`.split("\n")
+  s.executables   = `git ls-files -- bin`.split("\n").map{ |f| File.basename(f) }
   s.require_path  = 'lib'
 end


### PR DESCRIPTION
This removes the strict minor-level requirements on fog and rspec, since both are pretty good about semantic versioning.

This also swaps a lot of file parsing in the gemspec, using git instead.  This does introduce a git dependency, which may understandably be left out for Windows users, but given that the project itself is hosted on github, is this unreasonable?
