### PR TITLE
Updating outdated version in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ vagrant-joyent is a Vagrant provider for the Joyent Cloud and SmartDatacenter
     $ git clone https://github.com/someara/vagrant-joyent/
     $ cd vagrant-joyent
     $ gem build vagrant-joyent.gemspec ; 
-    $ vagrant plugin install vagrant-joyent-0.2.1.gem 
+    $ vagrant plugin install vagrant-joyent-0.3.0.gem 
     $ vagrant box add dummy ./dummy.box
 
 ## Usage


### PR DESCRIPTION
Build instructions don't work as-is because the gem version is up to 0.3.0 now
(instead of 0.2.1). This just patches it for those copy-pasters out there.
