### PR TITLE
Improve README, issues with box version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ installed with:
     $ vagrant plugin install vagrant-joyent
 
 Chances are, you'll also want to install the basebox for one of the
-Joyent images. Currently, only the [base64 13.4.0](http://wiki.joyent.com/wiki/display/jpc2/SmartMachine+Base#SmartMachineBase-13.4.0)
-image is supported. It can be installed with:
+Joyent images. Currently, only the [base64 13.4.0](http://wiki.joyent.com/wiki/display/jpc2/SmartMachine+Base#SmartMachineBase-13.4.0) image is supported.
+
+Whit vagrant 1.5+ this box can be installed with:
 
     $ vagrant box add apetresc/joyent-base64
 


### PR DESCRIPTION
Includes a short comment to use vagrant 1.5 before using vagrant box add (previous versions don't look for the box in vagrantcloud so the command doesn't work).

By the way, I'm having some trouble adding the box, it seems that the version name "13.4.0-2" is not valid due to the dash. Do you think it is possible to rename it to 13.4.0.2 or something like that?

```
# vagrant box add apetresc/joyent-base64
==> box: Loading metadata for box 'apetresc/joyent-base64'
    box: URL: https://vagrantcloud.com/apetresc/joyent-base64
A version of the box you're loading is formatted in a way that
Vagrant cannot parse: '13.4.0-2'. Please reformat the version
to be properly formatted. It should be in the format of
X.Y.Z.
```
