### PR TITLE
Fix problem with -i argument to rsync/ssh

### DIFF
--- a/lib/vagrant-joyent/action/sync_folders.rb
+++ b/lib/vagrant-joyent/action/sync_folders.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
             # Rsync over to the guest path using the SSH info
             command = [
               "rsync", "--verbose", "--archive", "-z",
-              "-e", "ssh -o StrictHostKeyChecking=no -p #{ssh_info[:port]} -i '#{ssh_info[:keyfile]}'",
+              "-e", "ssh -o StrictHostKeyChecking=no -p #{ssh_info[:port]} -i '#{ssh_info[:private_key_path]}'",
               hostpath,
              "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}" ]
 


### PR DESCRIPTION
Hi, I found a small problem with the rsync command when using non-default ssh keys. I noticed things would work only if I would create a ~/.ssh/config file and add there by hand the server I wanted to rsync to plus the key I wanted to use. Spelunked a bit more and put the following two statements near the point you create the rsync command and got this:

``` sh
ssh_info: {:host=>"165.225.167.219", :port=>22, :private_key_path=>["/home/vagrant/.ssh/joyent_id_rsa"], :username=>"ubuntu", :forward_agent=>false, :forward_x11=>false}
==> ktest: Rsyncing folder: /host_user/Documents/Impinj/inf_1/VMs/ => /vagrant
Rsync command => rsync --verbose --archive -z -e ssh -o StrictHostKeyChecking=no -p 22 -i '' /host_user/Documents/Impinj/inf_1/VMs/ ubuntu@165.225.167.219:/vagrant

```

So, in the code you seem to be giving as key path to the ssh -i argument, the **keyfile** element of your vagrant provider, but that item is not part of the ssh_info hash which you are using to populate your rsync. The needed info however is in ssh_info[:private_key_path] as can be seen above.

 So I just changed that and now I do not need to use a .ssh/config file.

HTH.
